### PR TITLE
Fixes Issue #12 - Clickable Links

### DIFF
--- a/app/src/main/java/org/disrupted/rumble/userinterface/activity/DisplayStatusActivity.java
+++ b/app/src/main/java/org/disrupted/rumble/userinterface/activity/DisplayStatusActivity.java
@@ -23,6 +23,8 @@ import android.support.v7.app.AppCompatActivity;
 import org.disrupted.rumble.util.Log;
 import android.view.MenuItem;
 import android.view.View;
+import android.text.method.LinkMovementMethod;
+import android.text.util.Linkify;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.TextView;
@@ -110,11 +112,16 @@ public class DisplayStatusActivity extends AppCompatActivity {
         groupNameView.setText(status.getGroup().getName());
         groupNameView.setTextColor(generator.getColor(status.getGroup().getGid()));
 
-        // we draw the status (with clickable hashtag)
+        // we draw the status (with clickable links)
         textView.setText(status.getPost());
+        textView.setMovementMethod(LinkMovementMethod.getInstance());
         textView.setTextIsSelectable(true);
 
-            /* we draw the attached file (if any) */
+        Linkify.addLinks(textView, Linkify.ALL);
+
+        /* todo: clickable hashtags */
+
+        /* we draw the attached file (if any) */
         if (status.hasAttachedFile()) {
             attachedView.setVisibility(View.VISIBLE);
             try {

--- a/app/src/main/java/org/disrupted/rumble/userinterface/adapter/StatusRecyclerAdapter.java
+++ b/app/src/main/java/org/disrupted/rumble/userinterface/adapter/StatusRecyclerAdapter.java
@@ -24,6 +24,7 @@ import android.support.v7.widget.PopupMenu;
 import android.support.v7.widget.RecyclerView;
 import android.text.SpannableString;
 import android.text.Spanned;
+import android.text.util.Linkify;
 import android.text.method.LinkMovementMethod;
 import android.text.style.ClickableSpan;
 import org.disrupted.rumble.util.Log;
@@ -167,6 +168,7 @@ public class StatusRecyclerAdapter extends RecyclerView.Adapter<StatusRecyclerAd
                 }
                 textView.setText(ss);
                 textView.setMovementMethod(LinkMovementMethod.getInstance());
+                Linkify.addLinks(textView, Linkify.ALL);
 
                 /* we draw the attached file (if any) */
                 if (status.hasAttachedFile()) {


### PR DESCRIPTION
This PR fixes [Issue 12](https://github.com/Marlinski/Rumble/issues/12).

Web URLs, Telephone Numbers & Email address are now clickable in both Home Activity and Status Activity, though hashtags are not yet clickable in Status Activity (they were already clickable at Home Activity).
