### PR TITLE
Toast Notification for User Feedback

### DIFF
--- a/app/src/main/java/org/disrupted/rumble/userinterface/activity/settings/StorageActivity.java
+++ b/app/src/main/java/org/disrupted/rumble/userinterface/activity/settings/StorageActivity.java
@@ -28,6 +28,7 @@ import android.view.MenuItem;
 import android.view.View;
 import android.widget.Button;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import org.disrupted.rumble.R;
 import org.disrupted.rumble.database.DatabaseFactory;
@@ -35,6 +36,8 @@ import org.disrupted.rumble.userinterface.events.UserWipeChatMessages;
 import org.disrupted.rumble.userinterface.events.UserWipeData;
 import org.disrupted.rumble.userinterface.events.UserWipeFiles;
 import org.disrupted.rumble.userinterface.events.UserWipeStatuses;
+import org.disrupted.rumble.database.events.ChatWipedEvent;
+import org.disrupted.rumble.database.events.StatusWipedEvent;
 import org.disrupted.rumble.userinterface.views.SimpleHistogram;
 import org.disrupted.rumble.util.FileUtil;
 
@@ -59,8 +62,22 @@ public class StorageActivity extends AppCompatActivity {
     private TextView fileDetailText;
 
     @Override
+    protected void onStart() {
+	super.onStart();
+	if(!EventBus.getDefault().isRegistered(this))
+	    EventBus.getDefault().register(this);
+    }
+
+    @Override
     protected void onDestroy() {
         super.onDestroy();
+    }
+
+    @Override
+    protected void onStop() {
+	super.onStop();
+	if(EventBus.getDefault().isRegistered(this))
+	    EventBus.getDefault().unregister(this);
     }
 
     @Override
@@ -232,4 +249,21 @@ public class StorageActivity extends AppCompatActivity {
         return String.format("%.1f %sB", bytes / Math.pow(unit, exp), pre);
     }
 
+    /** user feedback after clearing chats **/
+    public void onEvent(ChatWipedEvent event) {
+	this.runOnUiThread(new Runnable () {
+	    public void run() {
+		Toast.makeText(getApplicationContext(), "Chats Cleared", Toast.LENGTH_LONG).show();
+	    }
+	});
+    }
+
+    /** user feedback after clearing statuses **/
+    public void onEvent(StatusWipedEvent event) {
+	this.runOnUiThread(new Runnable () {
+	    public void run() {
+	        Toast.makeText(getApplicationContext(), "All Status Cleared", Toast.LENGTH_LONG).show();
+	    }
+	});
+    }
 }

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -39,7 +39,7 @@
     <string name="navigation_drawer_hashtag">Hash குறிசொற்கள்</string>
     <string name="navigation_drawer_status_favorites">பிடித்தவை</string>
     <string name="navigation_drawer_settings">அமைப்புகள்</string>
-    <string name="navigation_drawer_exit">பணிநிறுத்தக</string>
+    <string name="navigation_drawer_exit">பணிநிறுத்துக</string>
 
     <string name="status_viewer">நிலை</string>
     <string name="status_more_option_like">விருப்பம்</string>


### PR DESCRIPTION
While testing the app with some of my friends, they said they had no clue about what happened as soon as they pressed "Clear Chat" / "Clear Statuses" under Storage Activity.

Though they can navigate to respective sections, I thought it would be better if we add toast notifications for giving them immediate feedback.

![toast_notification](https://cloud.githubusercontent.com/assets/788244/12036925/5e99661e-ae70-11e5-9966-3b963983e380.png)

Another minor commit in this PR, which fixes a typo in Tamil translation.
