### PR TITLE
Vibrates When New Chat Message is Received

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -84,6 +84,9 @@
         android:required="false"
         android:name="android.hardware.sensor.accelerometer"/>
 
+    <!--Permission to vibrate the device on incoming events -->
+    <uses-permission android:name="android.permission.VIBRATE"/>
+
 
     <application
         android:icon="@drawable/ic_launcher_rumble"

--- a/app/src/main/java/org/disrupted/rumble/userinterface/fragments/FragmentChatMessageList.java
+++ b/app/src/main/java/org/disrupted/rumble/userinterface/fragments/FragmentChatMessageList.java
@@ -19,6 +19,7 @@
 
 package org.disrupted.rumble.userinterface.fragments;
 
+import android.os.Vibrator;
 import android.content.Context;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
@@ -38,6 +39,7 @@ import org.disrupted.rumble.app.RumbleApplication;
 import org.disrupted.rumble.database.ChatMessageDatabase;
 import org.disrupted.rumble.database.DatabaseExecutor;
 import org.disrupted.rumble.database.DatabaseFactory;
+import org.disrupted.rumble.network.protocols.events.ChatMessageReceived;
 import org.disrupted.rumble.database.events.ChatMessageInsertedEvent;
 import org.disrupted.rumble.database.events.ChatMessageUpdatedEvent;
 import org.disrupted.rumble.database.events.ChatWipedEvent;
@@ -188,5 +190,18 @@ public class FragmentChatMessageList extends Fragment {
                     refreshChatMessages();
             }
         });
+    }
+
+    /** Vibrates when a chat message is recieved **/
+    public void onEvent(ChatMessageReceived event) {
+        getActivity().runOnUiThread(new Runnable () {
+	    @Override
+	    public void run() {
+	        if(!((HomeActivity)getActivity()).isChatHasFocus()) {
+		    Vibrator vibrator = (Vibrator) getActivity().getApplicationContext().getSystemService(Context.VIBRATOR_SERVICE);
+		    vibrator.vibrate(300);
+		}
+	    }
+	});
     }
 }


### PR DESCRIPTION
Since we do not have any system notifications at the moment and also since the chats are real-time which requires immediate attention of the user, I made the device to vibrate whenever a new chat message is received and the Chat screen is not in the focus.

Todo: Dismiss-able Android Tray Notifications
