### PR TITLE
Notifications on Chat Messages & Opening Images in Gallery

### DIFF
--- a/app/src/main/java/org/disrupted/rumble/network/NetworkCoordinator.java
+++ b/app/src/main/java/org/disrupted/rumble/network/NetworkCoordinator.java
@@ -421,6 +421,10 @@ public class NetworkCoordinator extends Service {
         // check the toggle variable before sending notification or vibration
         if (!isChatTabFocused) {
 	    Intent chatIntent = new Intent(this, HomeActivity.class);
+	    // on pressing this notification should open chat tab instead of status tab
+	    chatIntent.putExtra("chatTab", 1);
+	    chatIntent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
+
 	    PendingIntent pIntent =  PendingIntent.getActivity(this, 0, chatIntent, 0);
 
 	    chatCounter++;

--- a/app/src/main/java/org/disrupted/rumble/network/NetworkCoordinator.java
+++ b/app/src/main/java/org/disrupted/rumble/network/NetworkCoordinator.java
@@ -23,6 +23,7 @@ import android.os.Vibrator;
 import android.content.Context;
 
 import android.app.Notification;
+import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.app.Service;
 import android.content.Intent;
@@ -35,6 +36,7 @@ import org.disrupted.rumble.network.services.ServiceLayer;
 import org.disrupted.rumble.network.services.chat.ChatService;
 import org.disrupted.rumble.network.services.push.PushService;
 import org.disrupted.rumble.userinterface.activity.RoutingActivity;
+import org.disrupted.rumble.userinterface.activity.HomeActivity;
 import org.disrupted.rumble.network.linklayer.Scanner;
 import org.disrupted.rumble.network.linklayer.bluetooth.BluetoothLinkLayerAdapter;
 import org.disrupted.rumble.network.linklayer.LinkLayerAdapter;
@@ -70,11 +72,17 @@ public class NetworkCoordinator extends Service {
     public static final String ACTION_MAIN_ACTION      = "org.disruptedsystems.rumble.action.mainaction";
     public static final int    FOREGROUND_SERVICE_ID   = 4242;
 
+    // no particular rationale behind choosing this number, just followed above //
+    public static final int    CHAT_NOTIFICATION_ID = 4343;
+
     private static final String TAG = "NetworkCoordinator";
     private static final Object lock = new Object();
+    private static int chatCounter = 0;
 
     private Looper  serviceLooper;
     private Handler serviceHandler;
+
+    // toggle variable to control notification & vibration //
     private boolean isChatTabFocused;
 
     private List<LinkLayerAdapter>  adapters;
@@ -84,6 +92,7 @@ public class NetworkCoordinator extends Service {
 
     private List<Scanner>    scannerList;
     public  NeighbourManager neighbourManager;
+    private NotificationManager mNotificationManager;
 
     public boolean networkingStarted;
 
@@ -195,19 +204,26 @@ public class NetworkCoordinator extends Service {
                 PendingIntent pendingIntent = PendingIntent.getActivity(this, 0,
                         notificationIntent, 0);
 
-                Notification notification = new NotificationCompat.Builder(this)
-                        .setContentTitle("Rumble")
-                        .setTicker("Rumble started")
-                        .setContentText("Rumble started")
-                        .setSmallIcon(R.drawable.small_icon)
-                        .setContentIntent(pendingIntent)
-                        .setOngoing(true).build();
+		NotificationCompat.Builder notification = showNotification("Rumble", "Rumble Started", "Rumble Started", R.drawable.small_icon, pendingIntent, true);
 
-                startForeground(FOREGROUND_SERVICE_ID, notification);
-            }
+                startForeground(FOREGROUND_SERVICE_ID, notification.build());
+	    }
         }
 
         return START_STICKY;
+    }
+
+    /** method that prepares notification and returns notification builder instance **/
+    private NotificationCompat.Builder showNotification(String title, String ticker, String content, int iconId, PendingIntent pendingIntent, boolean onGoing){
+        NotificationCompat.Builder notification = new NotificationCompat.Builder(this)
+                        .setContentTitle(title)
+                        .setTicker(ticker)
+                        .setContentText(content)
+                        .setSmallIcon(iconId)
+                        .setContentIntent(pendingIntent)
+                        .setOngoing(onGoing);
+
+		return notification;
     }
 
     public Looper getServiceLooper() {
@@ -372,18 +388,55 @@ public class NetworkCoordinator extends Service {
     public void onEvent(NoSubscriberEvent event) {
     }
 
-    /** toggle variable **/
     public void onEvent(UserEnteredChatTab event) {
-        isChatTabFocused = true;
+
+	/* assigning true will prevent notification & vibration on new
+	 * ChatMessageReceived event since the user already in the chat
+	 * tab and application is in focus.
+	 * /
+	isChatTabFocused = true;
+
+	/* we reset the chat notification counter whenever
+	 * user visits the chat tab and clears the notification
+	 * /
+	 chatCounter = 0;
+
+	 /* since user visited the chat tab, any pending notifications of
+	  * chat are cleared.
+	  * /
+	 mNotificationManager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
+	 mNotificationManager.cancel(CHAT_NOTIFICATION_ID);
     }
 
     public void onEvent(UserLeftChatTab event) {
+        /* assigning false will enable notification & vibration on new
+	 * ChatMessageRecevied event whenever the chat tab and application
+	 * is not in focus.
+	 * /
         isChatTabFocused = false;
     }
 
     /** Vibrates when a chat message is recieved **/
     public void onEvent(ChatMessageReceived event) {
+        /** check the toggle variable before sending notification or vibration **/
         if (!isChatTabFocused) {
+	    Intent chatIntent = new Intent(this, HomeActivity.class);
+	    PendingIntent pIntent =  PendingIntent.getActivity(this, 0, chatIntent, 0);
+
+	    chatCounter++;
+	    String notificationContent;
+
+	    if (chatCounter == 1) {
+	       notificationContent = "" + chatCounter + " chat received";
+	    }
+	    else {
+	       notificationContent = "" + chatCounter + " chats received";
+	    }
+
+	    mNotificationManager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
+	    NotificationCompat.Builder notification = showNotification("Rumble", notificationContent, notificationContent, R.drawable.small_icon, pIntent, false);
+	    mNotificationManager.notify(CHAT_NOTIFICATION_ID, notification.setAutoCancel(true).build());
+
 	    Vibrator vibrator = (Vibrator) getApplicationContext().getSystemService(Context.VIBRATOR_SERVICE);
 	    vibrator.vibrate(300);
 	}

--- a/app/src/main/java/org/disrupted/rumble/network/NetworkCoordinator.java
+++ b/app/src/main/java/org/disrupted/rumble/network/NetworkCoordinator.java
@@ -19,6 +19,8 @@
 
 package org.disrupted.rumble.network;
 
+import android.os.Vibrator;
+import android.content.Context;
 
 import android.app.Notification;
 import android.app.PendingIntent;
@@ -39,6 +41,9 @@ import org.disrupted.rumble.network.linklayer.LinkLayerAdapter;
 import org.disrupted.rumble.network.linklayer.wifi.WifiLinkLayerAdapter;
 import org.disrupted.rumble.network.protocols.Protocol;
 import org.disrupted.rumble.network.protocols.rumble.RumbleProtocol;
+import org.disrupted.rumble.network.protocols.events.ChatMessageReceived;
+import org.disrupted.rumble.userinterface.events.UserEnteredChatTab;
+import org.disrupted.rumble.userinterface.events.UserLeftChatTab;
 
 import java.util.HashMap;
 import java.util.Iterator;
@@ -70,6 +75,7 @@ public class NetworkCoordinator extends Service {
 
     private Looper  serviceLooper;
     private Handler serviceHandler;
+    private boolean isChatTabFocused;
 
     private List<LinkLayerAdapter>  adapters;
     private Map<String, WorkerPool> workerPools;
@@ -366,4 +372,20 @@ public class NetworkCoordinator extends Service {
     public void onEvent(NoSubscriberEvent event) {
     }
 
+    /** toggle variable **/
+    public void onEvent(UserEnteredChatTab event) {
+        isChatTabFocused = true;
+    }
+
+    public void onEvent(UserLeftChatTab event) {
+        isChatTabFocused = false;
+    }
+
+    /** Vibrates when a chat message is recieved **/
+    public void onEvent(ChatMessageReceived event) {
+        if (!isChatTabFocused) {
+	    Vibrator vibrator = (Vibrator) getApplicationContext().getSystemService(Context.VIBRATOR_SERVICE);
+	    vibrator.vibrate(300);
+	}
+    }
 }

--- a/app/src/main/java/org/disrupted/rumble/network/NetworkCoordinator.java
+++ b/app/src/main/java/org/disrupted/rumble/network/NetworkCoordinator.java
@@ -72,7 +72,7 @@ public class NetworkCoordinator extends Service {
     public static final String ACTION_MAIN_ACTION      = "org.disruptedsystems.rumble.action.mainaction";
     public static final int    FOREGROUND_SERVICE_ID   = 4242;
 
-    // no particular rationale behind choosing this number, just followed above //
+    // no particular rationale behind choosing this number, just followed above
     public static final int    CHAT_NOTIFICATION_ID = 4343;
 
     private static final String TAG = "NetworkCoordinator";
@@ -82,7 +82,7 @@ public class NetworkCoordinator extends Service {
     private Looper  serviceLooper;
     private Handler serviceHandler;
 
-    // toggle variable to control notification & vibration //
+    // toggle variable to control notification & vibration
     private boolean isChatTabFocused;
 
     private List<LinkLayerAdapter>  adapters;
@@ -213,7 +213,7 @@ public class NetworkCoordinator extends Service {
         return START_STICKY;
     }
 
-    /** method that prepares notification and returns notification builder instance **/
+    // method that prepares notification and returns notification builder instance
     private NotificationCompat.Builder showNotification(String title, String ticker, String content, int iconId, PendingIntent pendingIntent, boolean onGoing){
         NotificationCompat.Builder notification = new NotificationCompat.Builder(this)
                         .setContentTitle(title)
@@ -393,17 +393,17 @@ public class NetworkCoordinator extends Service {
 	/* assigning true will prevent notification & vibration on new
 	 * ChatMessageReceived event since the user already in the chat
 	 * tab and application is in focus.
-	 * /
+	 */
 	isChatTabFocused = true;
 
 	/* we reset the chat notification counter whenever
 	 * user visits the chat tab and clears the notification
-	 * /
+	 */
 	 chatCounter = 0;
 
 	 /* since user visited the chat tab, any pending notifications of
 	  * chat are cleared.
-	  * /
+	  */
 	 mNotificationManager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
 	 mNotificationManager.cancel(CHAT_NOTIFICATION_ID);
     }
@@ -412,13 +412,13 @@ public class NetworkCoordinator extends Service {
         /* assigning false will enable notification & vibration on new
 	 * ChatMessageRecevied event whenever the chat tab and application
 	 * is not in focus.
-	 * /
+	 */
         isChatTabFocused = false;
     }
 
-    /** Vibrates when a chat message is recieved **/
+    // vibrates when a chat message is recieved
     public void onEvent(ChatMessageReceived event) {
-        /** check the toggle variable before sending notification or vibration **/
+        // check the toggle variable before sending notification or vibration
         if (!isChatTabFocused) {
 	    Intent chatIntent = new Intent(this, HomeActivity.class);
 	    PendingIntent pIntent =  PendingIntent.getActivity(this, 0, chatIntent, 0);

--- a/app/src/main/java/org/disrupted/rumble/userinterface/activity/DisplayStatusActivity.java
+++ b/app/src/main/java/org/disrupted/rumble/userinterface/activity/DisplayStatusActivity.java
@@ -28,6 +28,7 @@ import android.text.util.Linkify;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.TextView;
+import android.net.Uri;
 
 import com.amulyakhare.textdrawable.TextDrawable;
 import com.amulyakhare.textdrawable.util.ColorGenerator;
@@ -125,7 +126,7 @@ public class DisplayStatusActivity extends AppCompatActivity {
         if (status.hasAttachedFile()) {
             attachedView.setVisibility(View.VISIBLE);
             try {
-                File attachedFile = new File(FileUtil.getReadableAlbumStorageDir(), status.getFileName());
+                final File attachedFile = new File(FileUtil.getReadableAlbumStorageDir(), status.getFileName());
 
                 if (!attachedFile.isFile() || !attachedFile.exists())
                     throw new IOException("file does not exists");
@@ -137,13 +138,17 @@ public class DisplayStatusActivity extends AppCompatActivity {
                         .into(attachedView);
 
                 final String filename =  status.getFileName();
+
+		/* we open the attached image file in gallery */
                 attachedView.setOnClickListener(new View.OnClickListener() {
                     @Override
                     public void onClick(View view) {
                         Log.d(TAG, "trying to open: " + filename);
-                        Intent intent = new Intent(DisplayStatusActivity.this, DisplayImage.class);
-                        intent.putExtra("IMAGE_NAME", filename);
-                        startActivity(intent);
+			Intent intent = new Intent();
+			intent.setAction(Intent.ACTION_VIEW);
+			intent.setDataAndType(Uri.parse("file://"+attachedFile.getAbsolutePath()), "image/*");
+			startActivity(intent);
+
                     }
                 });
             } catch (IOException ignore) {

--- a/app/src/main/java/org/disrupted/rumble/userinterface/activity/HomeActivity.java
+++ b/app/src/main/java/org/disrupted/rumble/userinterface/activity/HomeActivity.java
@@ -139,10 +139,23 @@ public class HomeActivity extends AppCompatActivity {
     }
 
     @Override
+    protected void onNewIntent(Intent intent){
+        super.onNewIntent(intent);
+	setIntent(intent);
+    }
+
+    @Override
     protected void onResume() {
         if (viewPager.getCurrentItem() == 1){
 	    EventBus.getDefault().post(new UserEnteredChatTab());
 	}
+
+	/* if resumed through chat notification, open the chat
+	 * tab directly else stay in the default statusTab.
+	 */
+	int chatTab = getIntent().getIntExtra("chatTab", 0);
+	viewPager.setCurrentItem(chatTab);
+
 	super.onResume();
     }
 

--- a/app/src/main/java/org/disrupted/rumble/userinterface/activity/HomeActivity.java
+++ b/app/src/main/java/org/disrupted/rumble/userinterface/activity/HomeActivity.java
@@ -52,6 +52,8 @@ import org.disrupted.rumble.userinterface.adapter.HomePagerAdapter;
 import org.disrupted.rumble.userinterface.fragments.FragmentChatMessageList;
 import org.disrupted.rumble.userinterface.fragments.FragmentNavigationDrawer;
 import org.disrupted.rumble.userinterface.fragments.FragmentNetworkDrawer;
+import org.disrupted.rumble.userinterface.events.UserEnteredChatTab;
+import org.disrupted.rumble.userinterface.events.UserLeftChatTab;
 
 import de.greenrobot.event.EventBus;
 
@@ -135,6 +137,21 @@ public class HomeActivity extends AppCompatActivity {
             EventBus.getDefault().unregister(this);
         super.onDestroy();
     }
+
+    @Override
+    protected void onResume() {
+        if (viewPager.getCurrentItem() == 1){
+	    EventBus.getDefault().post(new UserEnteredChatTab());
+	}
+	super.onResume();
+    }
+
+    @Override
+    protected void onPause() {
+        EventBus.getDefault().post(new UserLeftChatTab());
+        super.onPause();
+    }
+
 
     @Override
     public boolean onKeyUp(int keyCode, KeyEvent event) {
@@ -239,8 +256,10 @@ public class HomeActivity extends AppCompatActivity {
             FragmentChatMessageList fragment = (FragmentChatMessageList) pagerAdapter.getItem(1);
             if(position == 1) {
                 fragment.pageIn();
+		EventBus.getDefault().post(new UserEnteredChatTab());
             } else {
                 fragment.pageOut();
+		EventBus.getDefault().post(new UserLeftChatTab());
             }
         }
     };

--- a/app/src/main/java/org/disrupted/rumble/userinterface/adapter/StatusRecyclerAdapter.java
+++ b/app/src/main/java/org/disrupted/rumble/userinterface/adapter/StatusRecyclerAdapter.java
@@ -36,6 +36,7 @@ import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.TextView;
+import android.net.Uri;
 
 import com.amulyakhare.textdrawable.TextDrawable;
 import com.amulyakhare.textdrawable.util.ColorGenerator;
@@ -174,7 +175,7 @@ public class StatusRecyclerAdapter extends RecyclerView.Adapter<StatusRecyclerAd
                 if (status.hasAttachedFile()) {
                     attachedView.setVisibility(View.VISIBLE);
                     try {
-                        File attachedFile = new File(FileUtil.getReadableAlbumStorageDir(), status.getFileName());
+                        final File attachedFile = new File(FileUtil.getReadableAlbumStorageDir(), status.getFileName());
 
                         if (!attachedFile.isFile() || !attachedFile.exists())
                             throw new IOException("file does not exists");
@@ -186,13 +187,16 @@ public class StatusRecyclerAdapter extends RecyclerView.Adapter<StatusRecyclerAd
                                 .into(attachedView);
 
                         final String filename =  status.getFileName();
+
+			/* we open the attached image through gallery */
                         attachedView.setOnClickListener(new View.OnClickListener() {
                             @Override
                             public void onClick(View view) {
                                 Log.d(TAG, "trying to open: " + filename);
-                                Intent intent = new Intent(activity, DisplayImage.class);
-                                intent.putExtra("IMAGE_NAME", filename);
-                                activity.startActivity(intent);
+				Intent intent = new Intent();
+				intent.setAction(Intent.ACTION_VIEW);
+				intent.setDataAndType(Uri.parse("file://"+attachedFile.getAbsolutePath()), "image/*");
+				activity.startActivity(intent);
                             }
                         });
                     } catch (IOException ignore) {

--- a/app/src/main/java/org/disrupted/rumble/userinterface/events/UserEnteredChatTab.java
+++ b/app/src/main/java/org/disrupted/rumble/userinterface/events/UserEnteredChatTab.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2014 Lucien Loiseau
+ * This file is part of Rumble.
+ * Rumble is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Rumble is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with Rumble.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.disrupted.rumble.userinterface.events;
+
+/**
+ * @author Prasanna Venkadesh
+ */
+public class UserEnteredChatTab extends UserInteractionEvent {
+    @Override
+    public String shortDescription() {
+        return "";
+    }
+}

--- a/app/src/main/java/org/disrupted/rumble/userinterface/events/UserLeftChatTab.java
+++ b/app/src/main/java/org/disrupted/rumble/userinterface/events/UserLeftChatTab.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2014 Lucien Loiseau
+ * This file is part of Rumble.
+ * Rumble is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Rumble is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with Rumble.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.disrupted.rumble.userinterface.events;
+
+/**
+ * @author Prasanna Venkadesh
+ */
+public class UserLeftChatTab extends UserInteractionEvent {
+    @Override
+    public String shortDescription() {
+        return "";
+    }
+}

--- a/app/src/main/java/org/disrupted/rumble/userinterface/fragments/FragmentChatMessageList.java
+++ b/app/src/main/java/org/disrupted/rumble/userinterface/fragments/FragmentChatMessageList.java
@@ -39,7 +39,6 @@ import org.disrupted.rumble.app.RumbleApplication;
 import org.disrupted.rumble.database.ChatMessageDatabase;
 import org.disrupted.rumble.database.DatabaseExecutor;
 import org.disrupted.rumble.database.DatabaseFactory;
-import org.disrupted.rumble.network.protocols.events.ChatMessageReceived;
 import org.disrupted.rumble.database.events.ChatMessageInsertedEvent;
 import org.disrupted.rumble.database.events.ChatMessageUpdatedEvent;
 import org.disrupted.rumble.database.events.ChatWipedEvent;
@@ -190,18 +189,5 @@ public class FragmentChatMessageList extends Fragment {
                     refreshChatMessages();
             }
         });
-    }
-
-    /** Vibrates when a chat message is recieved **/
-    public void onEvent(ChatMessageReceived event) {
-        getActivity().runOnUiThread(new Runnable () {
-	    @Override
-	    public void run() {
-	        if(!((HomeActivity)getActivity()).isChatHasFocus()) {
-		    Vibrator vibrator = (Vibrator) getActivity().getApplicationContext().getSystemService(Context.VIBRATOR_SERVICE);
-		    vibrator.vibrate(300);
-		}
-	    }
-	});
     }
 }


### PR DESCRIPTION
5 Commits in this Pull Request:

**Commit 1**: When attached image file is displayed, people would like to Zoom in / Zoom out & Share on other platforms too. With `DisplayImage.java` only the image is displayed, but can't zoom in / zoom out or share. Instead of re-writing in `DisplayImage.java` we could just re-use the in-built gallery view.

**Commit 2**: Moved the vibration logic to be handled by Network Coordinator, so the device will vibrate on `ChatMessageReceived` even when the app is not in focus.

**Commit 3**: Display notifications when new chat messages are received.

**Commit 4**: Rectified incorrect comment statements made along with Commit 3.

**Commit 5**: Touching on Notification opens the Chat Tab instead of default Status Tab.
